### PR TITLE
NOISSUE - Fix metadata display error 

### DIFF
--- a/ui/web/templates/channelgroups.html
+++ b/ui/web/templates/channelgroups.html
@@ -136,7 +136,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                           </tr>
                           <script>
                             attachFormatJsonWithPrettifyListener({
-                              metadata: '{{ toJSON $g.Metadata }}',
+                              data: '{{ toJSON $g.Metadata }}',
                               id: "meta-{{ $i }}",
                             })
                           </script>

--- a/ui/web/templates/channels.html
+++ b/ui/web/templates/channels.html
@@ -213,7 +213,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                           </tr>
                           <script>
                             attachFormatJsonWithPrettifyListener({
-                              metadata: '{{ toJSON $c.Metadata }}',
+                              data: '{{ toJSON $c.Metadata }}',
                               id: "meta-{{ $i }}",
                             })
                           </script>

--- a/ui/web/templates/channelthings.html
+++ b/ui/web/templates/channelthings.html
@@ -140,7 +140,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                           </tr>
                           <script>
                             attachFormatJsonWithPrettifyListener({
-                              metadata: '{{ toJSON $t.Metadata }}',
+                              data: '{{ toJSON $t.Metadata }}',
                               id: "meta-{{ $i }}",
                             })
                           </script>

--- a/ui/web/templates/channelusers.html
+++ b/ui/web/templates/channelusers.html
@@ -230,7 +230,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                               </tr>
                               <script>
                                 attachFormatJsonWithPrettifyListener({
-                                  metadata: '{{ toJSON $u.Metadata }}',
+                                  data: '{{ toJSON $u.Metadata }}',
                                   id: "all-meta-{{ $i }}",
                                 })
                               </script>
@@ -306,7 +306,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                               </tr>
                               <script>
                                 attachFormatJsonWithPrettifyListener({
-                                  metadata: '{{ toJSON $u.Metadata }}',
+                                  data: '{{ toJSON $u.Metadata }}',
                                   id: "admin-meta-{{ $i }}",
                                 })
                               </script>
@@ -382,7 +382,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                               </tr>
                               <script>
                                 attachFormatJsonWithPrettifyListener({
-                                  metadata: '{{ toJSON $u.Metadata }}',
+                                  data: '{{ toJSON $u.Metadata }}',
                                   id: "editor-meta-{{ $i }}",
                                 })
                               </script>
@@ -458,7 +458,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                               </tr>
                               <script>
                                 attachFormatJsonWithPrettifyListener({
-                                  metadata: '{{ toJSON $u.Metadata }}',
+                                  data: '{{ toJSON $u.Metadata }}',
                                   id: "viewer-meta-{{ $i }}",
                                 })
                               </script>

--- a/ui/web/templates/groupchannels.html
+++ b/ui/web/templates/groupchannels.html
@@ -139,7 +139,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                           </tr>
                           <script>
                             attachFormatJsonWithPrettifyListener({
-                              metadata: '{{ toJSON $c.Metadata }}',
+                              data: '{{ toJSON $c.Metadata }}',
                               id: "meta-{{ $i }}",
                             })
                           </script>

--- a/ui/web/templates/groups.html
+++ b/ui/web/templates/groups.html
@@ -205,7 +205,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                           </tr>
                           <script>
                             attachFormatJsonWithPrettifyListener({
-                              metadata: '{{ toJSON $g.Metadata }}',
+                              data: '{{ toJSON $g.Metadata }}',
                               id: "meta-{{ $i }}",
                             })
                           </script>

--- a/ui/web/templates/groupusers.html
+++ b/ui/web/templates/groupusers.html
@@ -232,7 +232,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                               </tr>
                               <script>
                                 attachFormatJsonWithPrettifyListener({
-                                  metadata: '{{ toJSON $u.Metadata }}',
+                                  data: '{{ toJSON $u.Metadata }}',
                                   id: "all-meta-{{ $i }}",
                                 })
                               </script>
@@ -308,7 +308,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                               </tr>
                               <script>
                                 attachFormatJsonWithPrettifyListener({
-                                  metadata: '{{ toJSON $u.Metadata }}',
+                                  data: '{{ toJSON $u.Metadata }}',
                                   id: "admin-meta-{{ $i }}",
                                 })
                               </script>
@@ -384,7 +384,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                               </tr>
                               <script>
                                 attachFormatJsonWithPrettifyListener({
-                                  metadata: '{{ toJSON $u.Metadata }}',
+                                  data: '{{ toJSON $u.Metadata }}',
                                   id: "editor-meta-{{ $i }}",
                                 })
                               </script>
@@ -460,7 +460,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                               </tr>
                               <script>
                                 attachFormatJsonWithPrettifyListener({
-                                  metadata: '{{ toJSON $u.Metadata }}',
+                                  data: '{{ toJSON $u.Metadata }}',
                                   id: "viewer-meta-{{ $i }}",
                                 })
                               </script>

--- a/ui/web/templates/members.html
+++ b/ui/web/templates/members.html
@@ -121,17 +121,20 @@ SPDX-License-Identifier: Apache-2.0 -->
                             {{ end }}
                           </td>
                           <td class="meta-col">
-                            {{ range $k, $v := $m.Metadata }}
-                              <span class="badge bg-success">
-                                {{ $k }}:
-                                {{ $v }}
-                              </span>
-                            {{ end }}
+                            <div class="meta-div">
+                              <pre id="meta-{{ $i }}"></pre>
+                            </div>
                           </td>
                           <td class="created-col">
                             {{ $m.CreatedAt }}
                           </td>
                         </tr>
+                        <script>
+                          attachFormatJsonWithPrettifyListener({
+                            data: '{{ toJSON $m.Metadata }}',
+                            id: "meta-{{ $i }}",
+                          })
+                        </script>
                       {{ end }}
                     </tbody>
                   </table>

--- a/ui/web/templates/thingchannels.html
+++ b/ui/web/templates/thingchannels.html
@@ -150,7 +150,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                           </tr>
                           <script>
                             attachFormatJsonWithPrettifyListener({
-                              metadata: '{{ toJSON $c.Metadata }}',
+                              data: '{{ toJSON $c.Metadata }}',
                               id: "meta-{{ $i }}",
                             })
                           </script>

--- a/ui/web/templates/things.html
+++ b/ui/web/templates/things.html
@@ -235,7 +235,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                           </tr>
                           <script>
                             attachFormatJsonWithPrettifyListener({
-                              metadata: '{{ toJSON $t.Metadata }}',
+                              data: '{{ toJSON $t.Metadata }}',
                               id: "meta-{{ $i }}",
                             })
                           </script>

--- a/ui/web/templates/thingusers.html
+++ b/ui/web/templates/thingusers.html
@@ -190,7 +190,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                               </tr>
                               <script>
                                 attachFormatJsonWithPrettifyListener({
-                                  metadata: '{{ toJSON $u.Metadata }}',
+                                  data: '{{ toJSON $u.Metadata }}',
                                   id: "all-meta-{{ $i }}",
                                 })
                               </script>
@@ -267,7 +267,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                               </tr>
                               <script>
                                 attachFormatJsonWithPrettifyListener({
-                                  metadata: '{{ toJSON $u.Metadata }}',
+                                  data: '{{ toJSON $u.Metadata }}',
                                   id: "admin-meta-{{ $i }}",
                                 })
                               </script>

--- a/ui/web/templates/users.html
+++ b/ui/web/templates/users.html
@@ -222,7 +222,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                           </tr>
                           <script>
                             attachFormatJsonWithPrettifyListener({
-                              metadata: '{{ toJSON $u.Metadata }}',
+                              data: '{{ toJSON $u.Metadata }}',
                               id: "meta-{{ $i }}",
                             })
                           </script>


### PR DESCRIPTION
<!-- Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0 -->

# What type of PR is this?

<!--

Pull request title should be `AMDM-XXX - description` or `NOISSUE - description` where XXX is ID of issue that this PR relate to.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

- Provide tests for your changes.
- Use descriptive commit messages.
- Comment your code where appropriate.
- Squash your commits
- Update any related documentation.
-->

<!--(check all applicable)-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Dependency Update

## What does this do?
fix metadata not being displayed due to wrong naming of config field
<!--
Please provide a brief description of what this PR is intended to do.
Include List any changes that modify/break current functionality.
-->

## Which issue(s) does this PR fix/relate to?

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "Resolves #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

NOISSUE

## Have you included tests for your changes?

<!--Please confirm the following before submitting your PR, thank you!-->

- [ ] Yes
- [x] No, and this is why: <!--please replace this line with details on why tests have not been included-->

## Did you document any new/modified functionality?

<!--Please confirm the following before submitting your PR, thank you!-->

- [ ] Yes
- [x] No, and this is why: <!--please replace this line with details on why documentation has not been included-->

### Notes

<!--Please provide any additional information you feel is important.-->
